### PR TITLE
Fix installation, startup, and other first-run errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Take into account that with the default configuration, every time you `ddev star
 
 The service will automatically start when run: `ddev start` or `ddev restart`.
 
-By default, xhgui will be available at  <http://>`<your site>`:8282. Note that it's http only.
+By default, xhgui will be available at  <https://>`<your site>`:8143.
 
 Remember, if you updated `settings.ddev.php` or `wp-config-ddev.php`, these file will be overwritten unless you remove the `#ddev-generated`.
 

--- a/docker-compose.xhgui.yaml
+++ b/docker-compose.xhgui.yaml
@@ -2,7 +2,9 @@
 services:
   xhgui:
     # https://hub.docker.com/r/xhgui/xhgui/tags
-    image: xhgui/xhgui:latest
+    build:
+      dockerfile: Dockerfile
+      context: xhgui
     container_name: ddev-${DDEV_SITENAME}-xhgui
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}

--- a/docker-compose.xhgui.yaml
+++ b/docker-compose.xhgui.yaml
@@ -27,7 +27,7 @@ services:
 
   xhgui-mongo:
     # https://hub.docker.com/r/percona/percona-server-mongodb/tags
-    image: percona/percona-server-mongodb:3.6
+    image: percona/percona-server-mongodb:6.0-multi
     container_name: ddev-${DDEV_SITENAME}-xhgui-mongo
     command: --storageEngine=wiredTiger
     restart: always

--- a/docker-compose.xhgui.yaml
+++ b/docker-compose.xhgui.yaml
@@ -12,11 +12,14 @@ services:
       - ./xhgui/nginx.conf:/etc/nginx/http.d/default.conf:ro
       - ./xhgui/xhgui.config.php:/var/www/xhgui/config/config.php
     environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=8142:80
+      - HTTPS_EXPOSE=8143:80
       - XHGUI_MONGO_HOSTNAME=xhgui-mongo
       - XHGUI_MONGO_DATABASE=xhprof
-    ports:
-      - "8142:80"
     links:
+      - xhgui-mongo
+    depends_on:
       - xhgui-mongo
 
   web:

--- a/install.yaml
+++ b/install.yaml
@@ -57,6 +57,7 @@ pre_install_actions:
 # DDEV environment variables can be interpolated into these filenames
 project_files:
 - docker-compose.xhgui.yaml
+- xhgui/Dockerfile
 - xhgui/xhgui.config.php
 - xhgui/examples/xhgui.collector.config.php
 - xhgui/examples/xhgui.collector.php

--- a/install.yaml
+++ b/install.yaml
@@ -61,4 +61,3 @@ project_files:
 - xhgui/examples/xhgui.collector.config.php
 - xhgui/examples/xhgui.collector.php
 - xhgui/nginx.conf
-- xhgui-mongo/xhgui.js

--- a/install.yaml
+++ b/install.yaml
@@ -61,3 +61,4 @@ project_files:
 - xhgui/examples/xhgui.collector.config.php
 - xhgui/examples/xhgui.collector.php
 - xhgui/nginx.conf
+- xhprof/xhprof_prepend.php

--- a/install.yaml
+++ b/install.yaml
@@ -57,7 +57,7 @@ pre_install_actions:
 # DDEV environment variables can be interpolated into these filenames
 project_files:
 - docker-compose.xhgui.yaml
-- xhgui/config.default.php
+- xhgui/xhgui.config.php
 - xhgui/examples/xhgui.collector.config.php
 - xhgui/examples/xhgui.collector.php
 - xhgui/nginx.conf

--- a/xhgui-mongo/mongo.init.d
+++ b/xhgui-mongo/mongo.init.d
@@ -1,3 +1,4 @@
+#ddev-generated
 db.results.ensureIndex( { 'meta.SERVER.REQUEST_TIME' : -1 } );
 db.results.ensureIndex( { 'profile.main().wt' : -1 } );
 db.results.ensureIndex( { 'profile.main().mu' : -1 } );

--- a/xhgui/Dockerfile
+++ b/xhgui/Dockerfile
@@ -1,0 +1,3 @@
+FROM xhgui/xhgui:latest
+
+RUN echo 'memory_limit=512M' >> $PHP_INI_DIR/conf.d/99-memory-limit.ini

--- a/xhgui/examples/xhgui.collector.config.php
+++ b/xhgui/examples/xhgui.collector.config.php
@@ -1,4 +1,5 @@
 <?php
+#ddev-generated
 
 /**
  * @file

--- a/xhgui/examples/xhgui.collector.php
+++ b/xhgui/examples/xhgui.collector.php
@@ -1,5 +1,6 @@
 <?php
 
+#ddev-generated
 /**
  * @file
  */

--- a/xhprof/xhprof_prepend.php
+++ b/xhprof/xhprof_prepend.php
@@ -1,0 +1,5 @@
+<?php
+
+// ddev's built in xhprof handler breaks our own. If we leave ddev-generated in
+// this file, then ddev xhprof will overwrite this file.
+return;


### PR DESCRIPTION
@tyler36 good job nerdsniping me by writing a readme that looked like the initial setup would work out of the box!

This PR replaces https://github.com/tyler36/ddev-xhgui/pull/2 as it turns out there was more to do then just fix the configuration.

* Fix a few typos in the install.yaml file.
* Support reinstalls by adding ddev-generated tags.
* Upgrade mongo so it works on ARM mac's.
* Exposes xhgui over https.
* Fixes ddev's default xhgui handler causing a fatal, because it consumes data before us.
* Increases the memory limit because I fairly easily hit the 128MB limit profiling a real site.

This branch can be tested with:

```console
ddev get https://github.com/deviantintegral/ddev-xhgui/tarball/fix-startup
```