### PR TITLE
Improve addon install

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -6,13 +6,8 @@ name: ddev-xhgui
 # DDEV environment variables can be interpolated into these actions
 pre_install_actions:
   # Actions with #ddev-nodisplay will not show the execution of the action, but may show their output
-# - |
-  # #ddev-nodisplay
-  #ddev-description:Check architecture type for incompatible arm64 type
-  # if [ "$(arch)" = "arm64" -o "$(arch)" = "aarch64" ]; then
-    # echo "This package does not work on arm64 machines";
-    # exit 1;
-  #fi
+- |
+  mkdir -p .ddev/xhgui-mongo/mongo.init.d
 
 # - "docker volume rm ddev-${DDEV_PROJECT}_solr 2>/dev/null || true"
 #- |

--- a/xhgui/Dockerfile
+++ b/xhgui/Dockerfile
@@ -1,3 +1,4 @@
+#ddev-generated
 FROM xhgui/xhgui:latest
 
 RUN echo 'memory_limit=512M' >> $PHP_INI_DIR/conf.d/99-memory-limit.ini


### PR DESCRIPTION
This PR improves the addon installation:
- adds a missing "#ddev-generated" file
- creates the mongo db directory

Previously, when trying to remove the addon, a permissions error was thrown. By creating the directly pre-install, the addon can be removed.