### PR TITLE
Simplify install.yaml and avoid pre-install actiions

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -1,9 +1,5 @@
 name: xhgui
 
-pre_install_actions:
-- |
-  mkdir -p ${DDEV_APPROOT}/.ddev/xhgui-mongo/mongo.init.d
-
 project_files:
 - docker-compose.xhgui.yaml
 - xhgui/Dockerfile

--- a/install.yaml
+++ b/install.yaml
@@ -1,55 +1,9 @@
-name: ddev-xhgui
+name: xhgui
 
-# pre_install_actions - list of actions to run before installing the addon.
-# Examples would be removing an extraneous docker volume,
-# or doing a sanity check for requirements.
-# DDEV environment variables can be interpolated into these actions
 pre_install_actions:
-  # Actions with #ddev-nodisplay will not show the execution of the action, but may show their output
 - |
-  mkdir -p .ddev/xhgui-mongo/mongo.init.d
+  mkdir -p ${DDEV_APPROOT}/.ddev/xhgui-mongo/mongo.init.d
 
-# - "docker volume rm ddev-${DDEV_PROJECT}_solr 2>/dev/null || true"
-#- |
-#  # Using #ddev-nodisplay tells ddev to be quiet about this action and not show it or its output.
-#  #ddev-nodisplay
-#  #ddev-description:Remove solr volume
-#  if ! ( ddev debug capabilities 2>/dev/null | grep multiple-dockerfiles >/dev/null 2>&1 ) ; then
-#    echo "This add-on requires DDEV v1.19.4 or higher, please upgrade." && exit 2
-#  fi
-#- 'echo "what is your platform.sh token" && read x'
-
-# This item shows templating using DDEV environment variables.
-# -
-#   #ddev-description:Touch a file to create it
-#   touch somefile.${DDEV_PROJECT_TYPE}.${DDEV_DOCROOT}.txt
-#
-
-# This item shows complex go templating possibilities based on yaml_read_files
-#- |
-#- #ddev-description:Create a config.platformsh.yaml
-#  cat <<EOF >.ddev/config.platformsh.yaml
-#  php_version: {{ trimPrefix "php:" .platformapp.type }}
-#  database:
-#    type: {{ regexReplaceAll ":.*$" .services.db.type "" }}
-#    version: {{ regexReplaceAll "^.*:" .services.db.type "" }}
-#
-#  docroot: {{ dig "web" "locations" "/" "root" "notfound" .platformapp }}
-#  {{ if eq .platformapp.build.flavor "composer" }}
-#  hooks:
-#    post-start:
-#      - composer: install
-#  {{ if .platformapp.hooks.deploy }}
-#      - exec: "{{ trimAll "\n" .platformapp.hooks.deploy | splitList "\n" | join ` && ` }}"
-#  {{ end }}
-#  {{ end }}
-#
-#  EOF
-
-# list of files and directories listed that are copied into project .ddev directory
-# Each file should contain #ddev-generated so it can be replaced by a later `ddev get`
-# if it hasn't been modified by the user.
-# DDEV environment variables can be interpolated into these filenames
 project_files:
 - docker-compose.xhgui.yaml
 - xhgui/Dockerfile
@@ -58,3 +12,4 @@ project_files:
 - xhgui/examples/xhgui.collector.php
 - xhgui/nginx.conf
 - xhprof/xhprof_prepend.php
+- xhgui-mongo/mongo.init.d

--- a/xhgui-mongo/mongo.init.d
+++ b/xhgui-mongo/mongo.init.d
@@ -1,6 +1,0 @@
-#ddev-generated
-db.results.ensureIndex( { 'meta.SERVER.REQUEST_TIME' : -1 } );
-db.results.ensureIndex( { 'profile.main().wt' : -1 } );
-db.results.ensureIndex( { 'profile.main().mu' : -1 } );
-db.results.ensureIndex( { 'profile.main().cpu' : -1 } );
-db.results.ensureIndex( { 'meta.url' : 1 } );

--- a/xhgui-mongo/mongo.init.d/.gitmanaged
+++ b/xhgui-mongo/mongo.init.d/.gitmanaged
@@ -1,0 +1,1 @@
+#ddev-generated


### PR DESCRIPTION
I was just reviewing the readme and looking around.

* Please use the name `xhgui` if that's possible, rather than `ddev-xhgui`
* This removes comments that can only confuse in the install.yaml
* Instead of doing a `mkdir`, just provide the necessary directory in install.yaml