### PR TITLE
Use official ddev-mongo addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ Profiling in a production environment is not recommended.
 
 ## Getting started
 
-- Install the `ddev-xhgui` add-on:
+- Install the `ddev-mongo` and `ddev-xhgui` add-ons:
 
   ```shell
+  ddev get ddev/ddev-mongo
   ddev get tyler36/ddev-xhgui
   ddev restart
   ```

--- a/docker-compose.xhgui.yaml
+++ b/docker-compose.xhgui.yaml
@@ -17,12 +17,12 @@ services:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       - HTTP_EXPOSE=8142:80
       - HTTPS_EXPOSE=8143:80
-      - XHGUI_MONGO_HOSTNAME=xhgui-mongo
+      - XHGUI_MONGO_HOSTNAME=mongo
       - XHGUI_MONGO_DATABASE=xhprof
     links:
-      - xhgui-mongo
+      - mongo
     depends_on:
-      - xhgui-mongo
+      - mongo
 
   web:
     links:
@@ -30,22 +30,9 @@ services:
     depends_on:
       - xhgui
 
-  xhgui-mongo:
-    # https://hub.docker.com/r/percona/percona-server-mongodb/tags
-    image: percona/percona-server-mongodb:6.0-multi
-    container_name: ddev-${DDEV_SITENAME}-xhgui-mongo
-    command: --storageEngine=wiredTiger
-    restart: always
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
-    environment:
-      - MONGO_INITDB_DATABASE=xhprof
+  mongo:
     volumes:
       - ./xhgui-mongo/mongo.init.d:/docker-entrypoint-initdb.d
-      - xhgui-mongo:/data/db
-    expose:
-      - "27017"
-
+      - mongo:/data/db
 volumes:
-  xhgui-mongo:
+  mongo:

--- a/install.yaml
+++ b/install.yaml
@@ -10,3 +10,6 @@ project_files:
 - xhgui/nginx.conf
 - xhprof/xhprof_prepend.php
 - xhgui-mongo/mongo.init.d
+
+dependencies:
+  - ddev/ddev-mongo

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -42,6 +42,7 @@ collector_checks() {
   set -eu -o pipefail
   cd ${TESTDIR}
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get ddev/ddev-mongo
   ddev get ${DIR}
   ddev restart
 
@@ -53,6 +54,7 @@ collector_checks() {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
   echo "# ddev get tyler36/ddev-xhgui with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get ddev/ddev-mongo
   ddev get tyler36/ddev-xhgui
   ddev restart
 
@@ -75,6 +77,7 @@ require_once '/mnt/ddev_config/xhgui/collector/xhgui.collector.php';
 echo 'Demo website';" >${TESTDIR}/public/index.php
 
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get ddev/ddev-mongo
   ddev get ${DIR}
   ddev restart
 

--- a/xhgui/xhgui.config.php
+++ b/xhgui/xhgui.config.php
@@ -24,18 +24,16 @@ return [
     // Database options for MongoDB.
     'mongodb' => [
         // 'hostname' and 'port' are used to build DSN for MongoClient
-        'hostname' => getenv('XHGUI_MONGO_HOSTNAME') ?: 'xhgui-mongo',
+        'hostname' => getenv('XHGUI_MONGO_HOSTNAME') ?: 'mongo',
         'port' => getenv('XHGUI_MONGO_PORT') ?: 27017,
         // The database name
-        'database' => getenv('XHGUI_MONGO_DATABASE') ?: 'xhprof',
+        'database' => getenv('XHGUI_MONGO_DATABASE') ?: 'db',
         // Additional options for the MongoClient constructor,
         // for example 'username', 'password', or 'replicaSet'.
         // See <https://www.php.net/mongoclient_construct#options>.
         'options' => [
-            /*
-            'username' => getenv('XHGUI_MONGO_USERNAME') ?: null,
-            'password' => getenv('XHGUI_MONGO_PASSWORD') ?: null,
-            */
+            'username' => getenv('XHGUI_MONGO_USERNAME') ?: 'db',
+            'password' => getenv('XHGUI_MONGO_PASSWORD') ?: 'db',
         ],
         // An array of options for the MongoDB driver.
         // Options include setting connection context options for SSL or logging callbacks.


### PR DESCRIPTION
This PR attempts to use the DDEV's mongo addon.

Fixes #13


## Notes
Currently, we use "percona/percona-server-mongodb:6.0-multi" for arm64 compatibility (00c1ccaf44e97392e014c34c904e77bd9ad4e260).