### PR TITLE
mongo service doesn't have labels to identify it

### DIFF
--- a/docker-compose.xhgui.yaml
+++ b/docker-compose.xhgui.yaml
@@ -36,6 +36,9 @@ services:
     container_name: ddev-${DDEV_SITENAME}-xhgui-mongo
     command: --storageEngine=wiredTiger
     restart: always
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
     environment:
       - MONGO_INITDB_DATABASE=xhprof
     volumes:


### PR DESCRIPTION
The mongo service doesn't get properly managed by DDEV because it's missing the key labels.

This adds the labels.