### PR TITLE
Use default DDEV database

### DIFF
--- a/config.xhgui.yaml
+++ b/config.xhgui.yaml
@@ -1,0 +1,5 @@
+#ddev-generated
+hooks:
+  post-start:
+  - exec: mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS xhgui; GRANT ALL ON xhgui.* to 'db'@'%';"
+    service: db

--- a/config.xhgui.yaml
+++ b/config.xhgui.yaml
@@ -1,5 +1,11 @@
 #ddev-generated
 hooks:
   post-start:
-  - exec: mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS xhgui; GRANT ALL ON xhgui.* to 'db'@'%';"
+  # Create a new database called "xhgui"
+  - exec: |
+      if [[ "$DDEV_DATABASE_FAMILY" == "postgres" ]]; then
+        echo "SELECT 'CREATE DATABASE xhgui' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'xhgui')\gexec" | psql > /dev/null
+      else
+        mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS xhgui; GRANT ALL ON xhgui.* to 'db'@'%';"
+      fi
     service: db

--- a/docker-compose.xhgui.yaml
+++ b/docker-compose.xhgui.yaml
@@ -18,7 +18,7 @@ services:
       - HTTP_EXPOSE=8142:80
       - HTTPS_EXPOSE=8143:80
       - XHGUI_SAVE_HANDLER=pdo
-      - XHGUI_PDO_DSN=${DDEV_DATABASE_FAMILY}:host=db;dbname=db
+      - XHGUI_PDO_DSN=${DDEV_DATABASE_FAMILY}:host=db;dbname=xhgui
       - XHGUI_PDO_USER=db
       - XHGUI_PDO_PASS=db
     links:

--- a/docker-compose.xhgui.yaml
+++ b/docker-compose.xhgui.yaml
@@ -19,6 +19,8 @@ services:
       - HTTPS_EXPOSE=8143:80
       - XHGUI_SAVE_HANDLER=pdo
       - XHGUI_PDO_DSN=${DDEV_DATABASE_FAMILY}:host=db;dbname=xhgui
+      # If using pgsql database, use the below line instead and remove "#ddev-generated" from top of file
+      # - XHGUI_PDO_DSN=pgsql:host=db;dbname=xhgui
       - XHGUI_PDO_USER=db
       - XHGUI_PDO_PASS=db
     links:

--- a/docker-compose.xhgui.yaml
+++ b/docker-compose.xhgui.yaml
@@ -17,35 +17,11 @@ services:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       - HTTP_EXPOSE=8142:80
       - HTTPS_EXPOSE=8143:80
-      - XHGUI_MONGO_HOSTNAME=xhgui-mongo
-      - XHGUI_MONGO_DATABASE=xhprof
+      - XHGUI_SAVE_HANDLER=pdo
+      - XHGUI_PDO_DSN=${DDEV_DATABASE_FAMILY}:host=db;dbname=db
+      - XHGUI_PDO_USER=db
+      - XHGUI_PDO_PASS=db
     links:
-      - xhgui-mongo
+      - db
     depends_on:
-      - xhgui-mongo
-
-  web:
-    links:
-      - xhgui
-    depends_on:
-      - xhgui
-
-  xhgui-mongo:
-    # https://hub.docker.com/r/percona/percona-server-mongodb/tags
-    image: percona/percona-server-mongodb:6.0-multi
-    container_name: ddev-${DDEV_SITENAME}-xhgui-mongo
-    command: --storageEngine=wiredTiger
-    restart: always
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
-    environment:
-      - MONGO_INITDB_DATABASE=xhprof
-    volumes:
-      - ./xhgui-mongo/mongo.init.d:/docker-entrypoint-initdb.d
-      - xhgui-mongo:/data/db
-    expose:
-      - "27017"
-
-volumes:
-  xhgui-mongo:
+      - db

--- a/docker-compose.xhgui.yaml
+++ b/docker-compose.xhgui.yaml
@@ -18,9 +18,7 @@ services:
       - HTTP_EXPOSE=8142:80
       - HTTPS_EXPOSE=8143:80
       - XHGUI_SAVE_HANDLER=pdo
-      - XHGUI_PDO_DSN=${DDEV_DATABASE_FAMILY}:host=db;dbname=xhgui
-      # If using pgsql database, use the below line instead and remove "#ddev-generated" from top of file
-      # - XHGUI_PDO_DSN=pgsql:host=db;dbname=xhgui
+      - DDEV_DATABASE_FAMILY=${DDEV_DATABASE_FAMILY}
       - XHGUI_PDO_USER=db
       - XHGUI_PDO_PASS=db
     links:

--- a/install.yaml
+++ b/install.yaml
@@ -2,6 +2,7 @@ name: xhgui
 
 project_files:
 - docker-compose.xhgui.yaml
+- config.xhgui.yaml
 - commands/host/xhgui
 - xhgui/Dockerfile
 - xhgui/xhgui.config.php

--- a/install.yaml
+++ b/install.yaml
@@ -9,4 +9,3 @@ project_files:
 - xhgui/collector/xhgui.collector.php
 - xhgui/nginx.conf
 - xhprof/xhprof_prepend.php
-- xhgui-mongo/mongo.init.d

--- a/install.yaml
+++ b/install.yaml
@@ -10,3 +10,7 @@ project_files:
 - xhgui/collector/xhgui.collector.php
 - xhgui/nginx.conf
 - xhprof/xhprof_prepend.php
+
+removal_actions:
+- if [[ "$DDEV_DATABASE_FAMILY" == "postgres" ]]; then ddev psql -U db -c "drop database xhgui"; fi
+- if [[ "$DDEV_DATABASE_FAMILY" != "postgres" ]]; then ddev mysql -uroot -proot -e "DROP DATABASE IF EXISTS xhgui"; fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -80,6 +80,11 @@ echo 'Demo website';" >${TESTDIR}/public/index.php
   # Check service works
   health_checks
   collector_checks
+
+  # Check it removes database on uninstall. 'mysql "name"' returns 1 if db exists, 0 if missing.
+  ddev mysql "xhgui" -e exit > /dev/null 2>&1 && echo "Database exists." | grep "exists"
+  ddev get --remove ${DIR}
+  ddev mysql "xhgui" -e exit > /dev/null 2>&1 && echo "Database exists." || echo "Database missing" | grep "missing"
 }
 
 @test "it can profile using a MySQL database" {
@@ -103,6 +108,11 @@ echo 'Demo website';" >${TESTDIR}/public/index.php
   # Check service works
   health_checks
   collector_checks
+
+  # Check it removes database on uninstall. 'mysql "name"' returns 1 if db exists, 0 if missing.
+  ddev mysql "xhgui" -e exit > /dev/null 2>&1 && echo "Database exists." | grep "exists"
+  ddev get --remove ${DIR}
+  ddev mysql "xhgui" -e exit > /dev/null 2>&1 && echo "Database exists." || echo "Database missing" | grep "missing"
 }
 
 @test "it can profile using a Postres database" {
@@ -126,4 +136,9 @@ echo 'Demo website';" >${TESTDIR}/public/index.php
   # Check service works
   health_checks
   collector_checks
+
+  # Check it removes database on uninstall. `psql "xhgui" -c '\q'` returns 1 if db exists, 0 if missing.
+  ddev psql "xhgui" -c '\q' > /dev/null 2>&1 && echo "Database exists." | grep "exists"
+  ddev get --remove ${DIR}
+  ddev psql "xhgui" -c '\q' > /dev/null 2>&1 && echo "Database exists." || echo "Database missing" | grep "missing"
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -2,15 +2,12 @@ setup() {
   set -eu -o pipefail
 
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export TESTDIR=~/tmp/ddev-xhgui
+  export PROJNAME=test-ddev-xhgui
+  export TESTDIR=~/tmp/${PROJNAME}
   mkdir -p $TESTDIR
-  export PROJNAME=ddev-xhgui
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} || true
   cd "${TESTDIR}"
-  ddev config --project-name=${PROJNAME}
-  ddev start -y
-  echo "# ddev started at $(date)" >&3
 }
 
 teardown() {
@@ -41,6 +38,7 @@ collector_checks() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
+  ddev config --project-name=${PROJNAME}
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${DIR}
   ddev restart
@@ -52,6 +50,7 @@ collector_checks() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
+  ddev config --project-name=${PROJNAME}
   echo "# ddev get tyler36/ddev-xhgui with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get tyler36/ddev-xhgui
   ddev restart
@@ -60,15 +59,61 @@ collector_checks() {
   health_checks
 }
 
-@test "a site can be profiled" {
+@test "it can profile using the default (mariadb) database" {
   set -eu -o pipefail
   cd ${TESTDIR}
 
   # Create test site
   echo "# Create a demo website at ${TESTDIR}" >&3
+  ddev config --docroot=public --create-docroot
   ddev composer require perftools/php-profiler
   ddev composer install
-  ddev config --docroot=public --create-docroot
+  echo "<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once '/mnt/ddev_config/xhgui/collector/xhgui.collector.php';
+echo 'Demo website';" >${TESTDIR}/public/index.php
+
+  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get ${DIR}
+  ddev restart
+
+  # Check service works
+  health_checks
+  collector_checks
+}
+
+@test "it can profile using a MySQL database" {
+  set -eu -o pipefail
+  cd ${TESTDIR}
+
+  # Create test site
+  echo "# Create a demo website at ${TESTDIR} using MySQL" >&3
+  ddev config --docroot=public --create-docroot --database=mysql:8.0
+  ddev composer require perftools/php-profiler
+  ddev composer install
+  echo "<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once '/mnt/ddev_config/xhgui/collector/xhgui.collector.php';
+echo 'Demo website';" >${TESTDIR}/public/index.php
+
+  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get ${DIR}
+  ddev restart
+
+  # Check service works
+  health_checks
+  collector_checks
+}
+
+@test "it can profile using a Postres database" {
+  set -eu -o pipefail
+  cd ${TESTDIR}
+
+  # Create test site
+  echo "# Create a demo website at ${TESTDIR} using Postgres" >&3
+  ddev config --docroot=public --create-docroot --database=postgres:16
+  ddev composer require perftools/php-profiler
+  ddev composer install
   echo "<?php
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once '/mnt/ddev_config/xhgui/collector/xhgui.collector.php';

--- a/xhgui-mongo/mongo.init.d/.gitmanaged
+++ b/xhgui-mongo/mongo.init.d/.gitmanaged
@@ -1,1 +1,0 @@
-#ddev-generated

--- a/xhgui/xhgui.config.php
+++ b/xhgui/xhgui.config.php
@@ -14,9 +14,9 @@ return [
 
     // Database options for PDO.
     'pdo' => [
-        'dsn' => getenv('XHGUI_PDO_DSN') ?: null,
-        'user' => getenv('XHGUI_PDO_USER') ?: null,
-        'pass' => getenv('XHGUI_PDO_PASS') ?: null,
+        'dsn' => getenv('XHGUI_PDO_DSN') ?: 'mysql:host=db;dbname=db',
+        'user' => getenv('XHGUI_PDO_USER') ?: 'db',
+        'pass' => getenv('XHGUI_PDO_PASS') ?: 'db',
         'table' => getenv('XHGUI_PDO_TABLE') ?: 'results',
         'tableWatch' => getenv('XHGUI_PDO_TABLE_WATCHES') ?: 'watches',
     ],

--- a/xhgui/xhgui.config.php
+++ b/xhgui/xhgui.config.php
@@ -14,7 +14,7 @@ return [
 
     // Database options for PDO.
     'pdo' => [
-        'dsn' => getenv('XHGUI_PDO_DSN') ?: 'mysql:host=db;dbname=db',
+        'dsn' => getenv('XHGUI_PDO_DSN') ?: 'mysql:host=db;dbname=xhgui',
         'user' => getenv('XHGUI_PDO_USER') ?: 'db',
         'pass' => getenv('XHGUI_PDO_PASS') ?: 'db',
         'table' => getenv('XHGUI_PDO_TABLE') ?: 'results',

--- a/xhgui/xhgui.config.php
+++ b/xhgui/xhgui.config.php
@@ -7,6 +7,11 @@
  * and return an array from there with your overriding settings.
  */
 
+$DDEV_DATABASE_FAMILY = getenv('DDEV_DATABASE_FAMILY', 'mysql');
+$XHGUI_PDO_DSN = $DDEV_DATABASE_FAMILY === 'postgres'
+    ? 'pgsql:host=db;dbname=xhgui'
+    : "$DDEV_DATABASE_FAMILY:host=db;dbname=xhgui";
+
 return [
     // Which backend to use for Xhgui_Saver.
     // Must be one of 'mongodb', or 'pdo'.
@@ -14,7 +19,7 @@ return [
 
     // Database options for PDO.
     'pdo' => [
-        'dsn' => getenv('XHGUI_PDO_DSN') ?: 'mysql:host=db;dbname=xhgui',
+        'dsn' => $XHGUI_PDO_DSN,
         'user' => getenv('XHGUI_PDO_USER') ?: 'db',
         'pass' => getenv('XHGUI_PDO_PASS') ?: 'db',
         'table' => getenv('XHGUI_PDO_TABLE') ?: 'results',


### PR DESCRIPTION
This PR 
- uses the default DDEV database
- removes Mongo as a dependency.

PDO does NOT have feature parity with MongoDB, see [Compatibility matrix](https://github.com/perftools/xhgui#compatibility-matrix). 
Not sure if PDO or MongoDb should be default.

See #16.


