### PR TITLE
A few improvements for the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,6 @@ Profiling in a production environment is not recommended.
    }
    ```
 
-- Run `ddev xhprof` to start profiling.
-  - XHGui is now available at `https://yourproject.ddev.site:8142`
-
 ### WordPress
 
 - Install `perftools/php-profiler`
@@ -81,8 +78,6 @@ Profiling in a production environment is not recommended.
    ```
 
 - Remove `#ddev-generated` from `wp-config-ddev.php` to prevent DDEV overriding it.
-- Run `ddev xhprof` to start profiling
-  - XHGui is now available at `https://yourproject.ddev.site:8142`
 
 ### Silverstripe
 
@@ -109,19 +104,20 @@ Profiling in a production environment is not recommended.
   }
   ```
 
-- Run `ddev xhprof` to start profiling
-  - XHGui is now available at `https://yourproject.ddev.site:8142`
-
 ## Usage
+Make sure your project is started then use the following command to enable profiling.
 
-The service will automatically start when run: `ddev start` or `ddev restart`.
+```shell
+ddev xhprof
+```
 
-By default, xhgui will be available at `https://yourproject.ddev.site:8143`.
-Use the following command to launch the xhgui in your browser:
+Next use the following command to launch the XHGui in your browser:
 
 ```shell
 ddev xhgui
 ```
+
+By default, XHGui will be available at `https://yourproject.ddev.site:8143`.
 
 For detailed information about a single request, click on the "Method" keyword on the "Recent runs" dashboard.
 
@@ -137,9 +133,9 @@ Use the following command to check the logs:
 
 ## Configuration
 
-To configure Xhgui, update `.ddev/xhgui/xhgui.config.php`.
+To configure XhGui, update `.ddev/xhgui/xhgui.config.php`.
 
-For example, to set xhgui to use `Asia/Toyko` timezone for dates:
+For example, to set XHGui to use `Asia/Toyko` timezone for dates:
 
 - Remove `#ddev-generated` from `.ddev/xhgui/xhgui.config.php`
 - Change the timezone value

--- a/README.md
+++ b/README.md
@@ -105,16 +105,10 @@ Profiling in a production environment is not recommended.
   ```
 
 ## Usage
-Make sure your project is started then use the following command to enable profiling.
+Run the following commands to enable profiling and then launch the XHGui in your browser.
 
 ```shell
-ddev xhprof
-```
-
-Next use the following command to launch the XHGui in your browser:
-
-```shell
-ddev xhgui
+ddev xhprof on && ddev xhgui
 ```
 
 By default, XHGui will be available at `https://yourproject.ddev.site:8143`.


### PR DESCRIPTION
An initial rough draft for the README.md (based on my comment in https://github.com/tyler36/ddev-xhgui/issues/23). The following things I would suggest to change. 

- A few times the wordmark XHGui was only written in lower case.
- Each "Framework configuration"-section had the following redundant snippet: 

```
Run ddev xhprof to start profiling.
XHGui is now available at https://yourproject.ddev.site:8142
```
Starting the profiling is only relevant to the usage section imho. therefore i've moved the how to enable xhprof to the usage section. plus there you also already have a link with the port as well. 

- In the usage section i've removed `The service will automatically start when run: ddev start or ddev restart.`  the project will start anyway even if it was stopped by just running `ddev xhprof on` or `ddev xhprof on && ddev xhgui`

