### PR TITLE
Bump github-action-add-on-test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: ddev/github-action-add-on-test@v0
+    - uses: ddev/github-action-add-on-test@v1
       with:
         ddev_version: ${{ matrix.ddev_version }}
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR bumps github-action-add-on-test to the `1` release.
This PR should resolve the failing tests between 2024-01-15 and 01-22.

## Background

Recent tests have failed due to permissions issue.
This is due to an upstream issue with keep-alive (https://github.com/gautamkrishnar/keepalive-workflow/issues/20).

This was fixed in github-action-add-on-test (https://github.com/ddev/github-action-add-on-test/issues/25), however, this addon was still using an beta version.
