### PR TITLE
Improve handling of `xhprof_prepend.php`

### DIFF
--- a/config.xhgui.yaml
+++ b/config.xhgui.yaml
@@ -9,3 +9,21 @@ hooks:
         mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS xhgui; GRANT ALL ON xhgui.* to 'db'@'%';"
       fi
     service: db
+  - exec: |
+      cat <<-PHP > .ddev/xhprof/xhprof_prepend.php
+      <?php
+      // DDEV's built in xhprof handler breaks our own.
+      // We'll temporarily override it here, but return control back later.
+      // If you don't want this behavior, comment out the hooks in ".ddev/config.xhgui.yaml".
+      return;
+      PHP
+  pre-stop:
+  - exec: |
+      cat <<-PHP > .ddev/xhprof/xhprof_prepend.php
+      <?php
+      // #ddev-generated
+      // We'll give back control of this file to DDEV. Next time it checks, it will see it has ownership
+      // and override this file with the current default.
+      // If you don't want this behavior, comment out the hooks in .ddev/config.xhgui.yaml.
+      return;
+      PHP

--- a/config.xhgui.yaml
+++ b/config.xhgui.yaml
@@ -10,20 +10,20 @@ hooks:
       fi
     service: db
   - exec: |
-      cat <<-PHP > .ddev/xhprof/xhprof_prepend.php
+      cat <<-EOF > .ddev/xhprof/xhprof_prepend.php
       <?php
       // DDEV's built in xhprof handler breaks our own.
       // We'll temporarily override it here, but return control back later.
       // If you don't want this behavior, comment out the hooks in ".ddev/config.xhgui.yaml".
       return;
-      PHP
+      EOF
   pre-stop:
   - exec: |
-      cat <<-PHP > .ddev/xhprof/xhprof_prepend.php
+      cat <<-EOF > .ddev/xhprof/xhprof_prepend.php
       <?php
       // #ddev-generated
       // We'll give back control of this file to DDEV. Next time it checks, it will see it has ownership
       // and override this file with the current default.
       // If you don't want this behavior, comment out the hooks in .ddev/config.xhgui.yaml.
       return;
-      PHP
+      EOF

--- a/install.yaml
+++ b/install.yaml
@@ -9,7 +9,6 @@ project_files:
 - xhgui/collector/xhgui.collector.config.php
 - xhgui/collector/xhgui.collector.php
 - xhgui/nginx.conf
-- xhprof/xhprof_prepend.php
 
 removal_actions:
 - if [[ "$DDEV_DATABASE_FAMILY" == "postgres" ]]; then ddev psql -U db -c "drop database xhgui"; fi

--- a/xhprof/xhprof_prepend.php
+++ b/xhprof/xhprof_prepend.php
@@ -1,5 +1,0 @@
-<?php
-
-// ddev's built in xhprof handler breaks our own. If we leave ddev-generated in
-// this file, then ddev xhprof will overwrite this file.
-return;


### PR DESCRIPTION
The default `xhpro_prepend.php` file that ships with recent flavors of DDEV is NOT compatible with this addon.

Currently, we take ownership of it so this addon can function. However, we don't return ownership. This could cause problems if the addon is removed or disabled.

This PR offers a different approach.

- use `post-start` hook to claim ownership.
- use `pre-stop` hook to return ownership.

This handles ownership while the addon is active.
But returns ownership when stop; thus DDEV will return to "default" state next time it checks the file.

Fixes #11