### PR TITLE
All added files must have #ddev-generated

### DIFF
--- a/xhprof/xhprof_prepend.php
+++ b/xhprof/xhprof_prepend.php
@@ -1,5 +1,5 @@
 <?php
-
+// #ddev-generated
 // ddev's built in xhprof handler breaks our own. If we leave ddev-generated in
 // this file, then ddev xhprof will overwrite this file.
 return;


### PR DESCRIPTION
Currently, a `ddev get tyler36/ddev-xhgui` followed by `ddev get --remove xhgui` gets a warning:

`NOT overwriting /Users/rfay/workspace/d10/.ddev/xhprof/xhprof_prepend.php. The #ddev-generated signature was not found in the file, so it will not be overwritten. You can remove the file and use DDEV get again if you want it to be replaced: signature was not found in file /Users/rfay/workspace/d10/.ddev/xhprof/xhprof_prepend.php`

This also means that upgrades won't be successful (because they discover that the file has apparently been modified and `#ddev-generated` removed.

This PR adds the `#ddev-generated`