### PR TITLE
Refactor xhgui launch command

### DIFF
--- a/commands/host/xhgui
+++ b/commands/host/xhgui
@@ -8,44 +8,8 @@
 DDEV_XHGUI_PORT=8143
 DDEV_XHGUI_HTTPS_PORT=8142
 
-FULLURL=${DDEV_PRIMARY_URL}
-HTTPS=""
-if [ ${DDEV_PRIMARY_URL%://*} = "https" ]; then HTTPS=true; fi
-
-if [[ ! -z "${GITPOD_INSTANCE_ID}" ]] || [[ "${CODESPACES}" == "true" ]]; then
-  FULLURL="${FULLURL/-${DDEV_HOST_WEBSERVER_PORT}/-${DDEV_XHGUI_PORT}}"
+if [ ${DDEV_PRIMARY_URL%://*} = "https" ]; then
+    ddev launch $DDEV_PRIMARY_URL:$DDEV_XHGUI_HTTPS_PORT
 else
-  if [ "${HTTPS}" = "" ]; then
-    FULLURL="${FULLURL%:[0-9]*}:${DDEV_XHGUI_PORT}"
-  else
-    FULLURL="${FULLURL%:[0-9]*}:${DDEV_XHGUI_HTTPS_PORT}"
-  fi
+    ddev launch $DDEV_PRIMARY_URL::$DDEV_XHGUI_PORT
 fi
-
-if [ -n "${1:-}" ]; then
-  if [[ ${1::1} != "/" ]]; then
-    FULLURL="${FULLURL}/"
-  fi
-
-  FULLURL="${FULLURL}${1}"
-fi
-
-if [ "${DDEV_DEBUG:-}" = "true" ]; then
-  printf "FULLURL $FULLURL\n" && exit 0
-fi
-
-case $OSTYPE in
-linux-gnu)
-  if [[ ! -z "${GITPOD_INSTANCE_ID}" ]]; then
-    gp preview ${FULLURL}
-  else
-    xdg-open ${FULLURL}
-  fi
-  ;;
-"darwin"*)
-  open ${FULLURL}
-  ;;
-"win*"* | "msys"*)
-  start ${FULLURL}
-  ;;
-esac

--- a/install.yaml
+++ b/install.yaml
@@ -10,6 +10,13 @@ project_files:
 - xhgui/collector/xhgui.collector.php
 - xhgui/nginx.conf
 
+pre_install_actions:
+  # Ensure we're on DDEV 1.23+. It's need for the `xhgui` command (launch by port).
+  - |
+    #ddev-nodisplay
+    #ddev-description:Checking DDEV version
+    (ddev debug capabilities | grep corepack >/dev/null) || (echo "Please upgrade DDEV to v1.23+ to enable launching." && false)
+
 removal_actions:
 - if [[ "$DDEV_DATABASE_FAMILY" == "postgres" ]]; then ddev psql -U db -c "drop database xhgui"; fi
 - if [[ "$DDEV_DATABASE_FAMILY" != "postgres" ]]; then ddev mysql -uroot -proot -e "DROP DATABASE IF EXISTS xhgui"; fi


### PR DESCRIPTION
DDEV introduced a way to reduce "launch" comand boilerplate using a port. https://github.com/ddev/ddev/pull/6024

This PR takes advantage of that, and reduces the laucnh down to a simple "port" implementation.

We'll need require DDEV 1.23 (?) during install. 
This is considered a breaking change and will require a point release.