### PR TITLE
Update references for official status

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Profiling in a production environment is not recommended.
 - Install the `ddev-xhgui` add-on:
 
   ```shell
-  ddev get tyler36/ddev-xhgui
+  ddev get ddev/ddev-xhgui
   ddev restart
   ```
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -51,8 +51,8 @@ collector_checks() {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
   ddev config --project-name=${PROJNAME}
-  echo "# ddev get tyler36/ddev-xhgui with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get tyler36/ddev-xhgui
+  echo "# ddev get ddev/ddev-xhgui with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get ddev/ddev-xhgui
   ddev restart
 
   # Check service works


### PR DESCRIPTION
## The Issue
This repository was made official today and thus moved from "tyler36/ddev-xhgui" to "ddev/ddev-xhgui".

References to "tyler36/ddev-xhgui" need to be updated.

## How This PR Solves The Issue

This PR makes the changes required in the docs and tests.
Github does a pretty good job at redirecting URLs.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

Fixes #3

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

