### PR TITLE
fix: typo in the HTTP port, for #31

### DIFF
--- a/commands/host/xhgui
+++ b/commands/host/xhgui
@@ -11,5 +11,5 @@ DDEV_XHGUI_HTTPS_PORT=8142
 if [ ${DDEV_PRIMARY_URL%://*} = "https" ]; then
     ddev launch $DDEV_PRIMARY_URL:$DDEV_XHGUI_HTTPS_PORT
 else
-    ddev launch $DDEV_PRIMARY_URL::$DDEV_XHGUI_PORT
+    ddev launch $DDEV_PRIMARY_URL:$DDEV_XHGUI_PORT
 fi


### PR DESCRIPTION
## The Issue

- #31

I noticed extra `:` which breaks the HTTP URL.

## How This PR Solves The Issue

Removes it.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

