### PR TITLE
Make add-on work w/o ddev-router, update tests

### DIFF
--- a/commands/host/xhgui
+++ b/commands/host/xhgui
@@ -8,8 +8,8 @@
 DDEV_XHGUI_PORT=8143
 DDEV_XHGUI_HTTPS_PORT=8142
 
-if [ ${DDEV_PRIMARY_URL%://*} = "https" ]; then
-    ddev launch $DDEV_PRIMARY_URL:$DDEV_XHGUI_HTTPS_PORT
+if [ ${DDEV_PRIMARY_URL%://*} = "http" ] || [ -n "${GITPOD_WORKSPACE_ID:-}" ] || [ "${CODESPACES:-}" = "true" ]; then
+    ddev launch :$DDEV_XHGUI_PORT
 else
-    ddev launch $DDEV_PRIMARY_URL:$DDEV_XHGUI_PORT
+    ddev launch :$DDEV_XHGUI_HTTPS_PORT
 fi

--- a/docker-compose.xhgui_norouter.yaml
+++ b/docker-compose.xhgui_norouter.yaml
@@ -1,0 +1,4 @@
+#ddev-generated
+# If omit_containers[ddev-router] then this file will be replaced
+# with another with a `ports` statement to directly expose port 80 to 8143
+services: {}

--- a/install.yaml
+++ b/install.yaml
@@ -2,6 +2,7 @@ name: xhgui
 
 project_files:
 - docker-compose.xhgui.yaml
+- docker-compose.xhgui_norouter.yaml
 - config.xhgui.yaml
 - commands/host/xhgui
 - xhgui/Dockerfile
@@ -11,11 +12,21 @@ project_files:
 - xhgui/nginx.conf
 
 pre_install_actions:
-  # Ensure we're on DDEV 1.23+. It's need for the `xhgui` command (launch by port).
+  # Ensure we're on DDEV 1.23+. It's required for the `xhgui` command (launch by port).
   - |
     #ddev-nodisplay
     #ddev-description:Checking DDEV version
     (ddev debug capabilities | grep corepack >/dev/null) || (echo "Please upgrade DDEV to v1.23+ to enable launching." && false)
+
+post_install_actions:
+  - |
+    #ddev-description:If router disabled, directly expose port
+    #
+    if ( {{ contains "ddev-router" (list .DdevGlobalConfig.omit_containers | toString) }} ); then
+      printf "#ddev-generated\nservices:\n  xhgui:\n    ports:\n      - 8143:80\n" > docker-compose.xhgui_norouter.yaml
+    fi
+  - |
+    echo "You can now use 'ddev xhgui' to launch XHGui"
 
 removal_actions:
 - if [[ "$DDEV_DATABASE_FAMILY" == "postgres" ]]; then ddev psql -U db -c "drop database xhgui"; fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,5 +1,8 @@
 setup() {
   set -eu -o pipefail
+  brew_prefix=$(brew --prefix)
+  load "${brew_prefix}/lib/bats-support/load.bash"
+  load "${brew_prefix}/lib/bats-assert/load.bash"
 
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
   export PROJNAME=test-ddev-xhgui
@@ -18,6 +21,17 @@ teardown() {
 }
 
 health_checks() {
+  set +u # bats-assert has unset variables so turn off unset check
+  # ddev restart is required because we have done `ddev get` on a new service
+  run ddev restart
+  assert_success
+  # Make sure we can hit the 8142 port successfully
+  curl -s -I -f https://${PROJNAME}.ddev.site:8142 >/tmp/curlout.txt
+  # Make sure `ddev xhgui` works
+  DDEV_DEBUG=true run ddev xhgui
+  assert_success
+  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site:8142"
+
   ddev exec "curl -s xhgui:80" | grep "XHGui - Run list"
 }
 
@@ -41,7 +55,6 @@ collector_checks() {
   ddev config --project-name=${PROJNAME}
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${DIR}
-  ddev restart
 
   # Check service works
   health_checks
@@ -53,7 +66,6 @@ collector_checks() {
   ddev config --project-name=${PROJNAME}
   echo "# ddev get ddev/ddev-xhgui with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ddev/ddev-xhgui
-  ddev restart
 
   # Check service works
   health_checks
@@ -75,7 +87,6 @@ echo 'Demo website';" >${TESTDIR}/public/index.php
 
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${DIR}
-  ddev restart
 
   # Check service works
   health_checks
@@ -103,7 +114,6 @@ echo 'Demo website';" >${TESTDIR}/public/index.php
 
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${DIR}
-  ddev restart
 
   # Check service works
   health_checks
@@ -131,7 +141,6 @@ echo 'Demo website';" >${TESTDIR}/public/index.php
 
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${DIR}
-  ddev restart
 
   # Check service works
   health_checks
@@ -141,4 +150,15 @@ echo 'Demo website';" >${TESTDIR}/public/index.php
   ddev psql "xhgui" -c '\q' > /dev/null 2>&1 && echo "Database exists." | grep "exists"
   ddev get --remove ${DIR}
   ddev psql "xhgui" -c '\q' > /dev/null 2>&1 && echo "Database exists." || echo "Database missing" | grep "missing"
+}
+
+@test "install from directory with nonstandard port" {
+  set -eu -o pipefail
+  cd ${TESTDIR}
+  ddev config --project-name=${PROJNAME} --router-http-port=8080 --router-https-port=8443
+  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get ${DIR}
+
+  # Check service works
+  health_checks
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -22,9 +22,6 @@ teardown() {
 
 health_checks() {
   set +u # bats-assert has unset variables so turn off unset check
-  # ddev restart is required because we have done `ddev get` on a new service
-  run ddev restart
-  assert_success
   # Make sure we can hit the 8142 port successfully
   curl -s -I -f https://${PROJNAME}.ddev.site:8142 >/tmp/curlout.txt
   # Make sure `ddev xhgui` works
@@ -55,6 +52,7 @@ collector_checks() {
   ddev config --project-name=${PROJNAME}
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${DIR}
+  ddev restart
 
   # Check service works
   health_checks
@@ -66,6 +64,7 @@ collector_checks() {
   ddev config --project-name=${PROJNAME}
   echo "# ddev get ddev/ddev-xhgui with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ddev/ddev-xhgui
+  ddev restart
 
   # Check service works
   health_checks
@@ -87,6 +86,7 @@ echo 'Demo website';" >${TESTDIR}/public/index.php
 
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${DIR}
+  ddev restart
 
   # Check service works
   health_checks
@@ -114,6 +114,7 @@ echo 'Demo website';" >${TESTDIR}/public/index.php
 
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${DIR}
+  ddev restart
 
   # Check service works
   health_checks
@@ -141,6 +142,7 @@ echo 'Demo website';" >${TESTDIR}/public/index.php
 
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${DIR}
+  ddev restart
 
   # Check service works
   health_checks
@@ -158,6 +160,7 @@ echo 'Demo website';" >${TESTDIR}/public/index.php
   ddev config --project-name=${PROJNAME} --router-http-port=8080 --router-https-port=8443
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${DIR}
+  ddev restart
 
   # Check service works
   health_checks


### PR DESCRIPTION
## The Issue

This add-on doesn't work in Gitpod.

## How This PR Solves The Issue

In terms of functionality, this add-on is similar to https://github.com/ddev/ddev-phpmyadmin
This PR contains recent fixes and improvements from `ddev-phpmyadmin`.

## Manual Testing Instructions

Test it locally and in Gitpod.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ddev/ddev)

```
ddev get https://github.com/ddev/ddev-xhgui/tarball/20240718_stasadev_norouter
ddev restart
ddev xhgui
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

