### PR TITLE
Add "release" tag to test

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -58,6 +58,7 @@ collector_checks() {
   health_checks
 }
 
+# bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )


### PR DESCRIPTION
## The Issue

## How This PR Solves The Issue
This PR adds the `test_tags=release` tag.
This allows conditional running of tests based on tag presence or absence.

This requires ddev-action-add-on `v2.1.0`.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

