### PR TITLE
Use ddev_version_constraint instead of checking capabilities

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -1,5 +1,7 @@
 name: xhgui
 
+ddev_version_constraint: ">=v1.24.0"
+
 project_files:
 - docker-compose.xhgui.yaml
 - docker-compose.xhgui_norouter.yaml
@@ -10,13 +12,6 @@ project_files:
 - xhgui/collector/xhgui.collector.config.php
 - xhgui/collector/xhgui.collector.php
 - xhgui/nginx.conf
-
-pre_install_actions:
-  # Ensure we're on DDEV 1.23+. It's required for the `xhgui` command (launch by port).
-  - |
-    #ddev-nodisplay
-    #ddev-description:Checking DDEV version
-    (ddev debug capabilities | grep corepack >/dev/null) || (echo "Please upgrade DDEV to v1.23+ to enable launching." && false)
 
 post_install_actions:
   - |


### PR DESCRIPTION
## The Issue

`ddev_version_constraint` is now a better way to ensure version than checking capabilities. 

## How This PR Solves The Issue

Use `ddev_version_constraint` instead.

