### PR TITLE
Automatically configure xhprof for xhgui, remove configuration requirements, fixes #33, fixes #30

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,6 @@
 - [Introduction](#introduction)
 - [Warning](#warning)
 - [Getting started](#getting-started)
-- [Framework configuration](#framework-configuration)
-  - [CakePHP](#cakephp)
-  - [Drupal](#drupal)
-  - [Laravel](#laravel)
-  - [OpenMage](#openmage)
-  - [Silverstripe](#silverstripe)
-  - [WordPress](#wordpress)
 - [Usage](#usage)
 - [Configuration](#configuration)
 
@@ -30,186 +23,23 @@ Profiling in a production environment is not recommended.
 
 ## Getting started
 
-- Install the `ddev-xhgui` add-on:
+- Install the `ddev-xhgui` add-on and restart your project
 
-  For DDEV v1.23.5 or above run
-
-  ```shell
-  ddev add-on get ddev/ddev-xhgui
-  ```
-
-  For earlier versions of DDEV run
-
-  ```shell
-  ddev get ddev/ddev-xhgui
-  ```
-
-  Then restart your project
-
-  ```shell
-  ddev restart
-  ```
-
-## Framework configuration
-
-### CakePHP
-
-- Install `perftools/php-profiler`
-
-   ```shell
-   ddev composer require perftools/php-profiler --dev
-   ```
-
-- Add the following line to `src/Application.php` to include the collector.
-
-   ```php
-    public function bootstrap(): void
-    {
-        parent::bootstrap();
-
-        // Below is the new code to add
-        if (file_exists("/mnt/ddev_config/xhgui/collector/xhgui.collector.php")) {
-            require_once "/mnt/ddev_config/xhgui/collector/xhgui.collector.php";
-        }
-   ```
-
-- Run `ddev xhprof` to start profiling.
-  - XHGui is now available at `https://yourproject.ddev.site:8142`
-
-### Drupal
-
-- Install `perftools/php-profiler`
-
-   ```shell
-   ddev composer require perftools/php-profiler --dev
-   ```
-
-- Add the following line to `web/sites/default/settings.php` to include the collector.
-
-   ```php
-   if (file_exists("/mnt/ddev_config/xhgui/collector/xhgui.collector.php")) {
-    require_once "/mnt/ddev_config/xhgui/collector/xhgui.collector.php";
-   }
-   ```
-
-- Run `ddev xhprof` to start profiling.
-  - XHGui is now available at `https://yourproject.ddev.site:8142`
-
-### Laravel
-
-- Install `perftools/php-profiler`
-
-   ```shell
-   ddev composer require perftools/php-profiler --dev
-   ```
-
-- Add the following line to `app/Providers/AppServiceProvider.php` to include the collector.
-
-   ```php
-    public function boot(): void
-    {
-        if (file_exists("/mnt/ddev_config/xhgui/collector/xhgui.collector.php")) {
-            require_once "/mnt/ddev_config/xhgui/collector/xhgui.collector.php";
-        }
-        ...
-   ```
-
-- Run `ddev xhprof` to start profiling.
-  - XHGui is now available at `https://yourproject.ddev.site:8142`
-
-### OpenMage
-
-- Install `perftools/php-profiler`
-
-   ```shell
-   ddev composer require perftools/php-profiler --dev
-   ```
-
-- Add the following line to `app/Mage.php`, right after the "AUTOLOADER PATCH", to include the collector.
-
-   ```php
-   if (file_exists("/mnt/ddev_config/xhgui/collector/xhgui.collector.php")) {
-    require_once "/mnt/ddev_config/xhgui/collector/xhgui.collector.php";
-   }
-   ```
-
-- Run `ddev xhprof` to start profiling.
-  - XHGui is now available at `https://yourproject.ddev.site:8142`
-
-### Silverstripe
-
-- Install `perftools/php-profiler`
-
-   ```shell
-   ddev composer require perftools/php-profiler --dev
-   ```
-
-- Add the following line to `public/index.php`, right after the autoload includes, to include the collector.
-
-  ```php
-  if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
-    require __DIR__ . '/../vendor/autoload.php';
-  } elseif (file_exists(__DIR__ . '/vendor/autoload.php')) {
-      require __DIR__ . '/vendor/autoload.php';
-  } else {
-      header('HTTP/1.1 500 Internal Server Error');
-      echo "autoload.php not found";
-      exit(1);
-  }
-  if (file_exists("/mnt/ddev_config/xhgui/collector/xhgui.collector.php")) {
-   require_once "/mnt/ddev_config/xhgui/collector/xhgui.collector.php";
-  }
-  ```
-
-- Run `ddev xhprof` to start profiling
-  - XHGui is now available at `https://yourproject.ddev.site:8142`
-
-### WordPress
-
-- Install `perftools/php-profiler`
-  - If using [bedrock](https://roots.io/bedrock/)
-
-   ```shell
-   ddev composer require perftools/php-profiler --dev
-   ```
-
-  - If using vanilla WordPress:
-
-   ```shell
-   git clone https://github.com/perftools/php-profiler.git
-   ```
-
-- Add the following line to `wp-config-ddev.php` to include the collector.
-
-   ```php
-   require_once __DIR__ . '/php-profiler/autoload.php';
-   if (file_exists("/mnt/ddev_config/xhgui/collector/xhgui.collector.php")) {
-     require_once "/mnt/ddev_config/xhgui/collector/xhgui.collector.php";
-   }
-   ```
-
-- Remove `#ddev-generated` from `wp-config-ddev.php` to prevent DDEV overriding it.
-- Run `ddev xhprof` to start profiling
-  - XHGui is now available at `https://yourproject.ddev.site:8142`
+```shell
+  ddev add-on get ddev/ddev-xhgui && ddev restart
+```
 
 ## Usage
 
-The service will automatically start when run: `ddev start` or `ddev restart`.
+When you want to start profiling, `ddev xhprof on`.
 
-By default, xhgui will be available at `https://yourproject.ddev.site:8143`.
-Use the following command to launch the xhgui in your browser:
-
-```shell
-ddev xhgui
-```
+The web profiling UI is at `https://yourproject.ddev.site:8143` or use `ddev xhgui` to launch it.
 
 For detailed information about a single request, click on the "Method" keyword on the "Recent runs" dashboard.
 
 ![Click GET method](./images/xhgui-get.png)
 
-Remember, if you updated `settings.ddev.php` or `wp-config-ddev.php`, these file will be overwritten unless you remove the `#ddev-generated`.
-
-Use the following command to check the logs:
+To check the xhgui service's logs:
 
    ```shell
    ddev logs -s xhgui
@@ -217,7 +47,7 @@ Use the following command to check the logs:
 
 ## Configuration
 
-To configure Xhgui, update `.ddev/xhgui/xhgui.config.php`.
+To configure Xhgui, add `.ddev/xhgui/xhgui.config.php`.
 
 For example, to set xhgui to use `Asia/Toyko` timezone for dates:
 

--- a/config.xhgui.yaml
+++ b/config.xhgui.yaml
@@ -10,11 +10,16 @@ hooks:
       fi
     service: db
   - exec: |
-      cat <<-EOF > .ddev/xhprof/xhprof_prepend.php
+      cat <<-'EOF' > .ddev/xhprof/xhprof_prepend.php
       <?php
       // DDEV's built in xhprof handler breaks our own.
       // We'll temporarily override it here, but return control back later.
       // If you don't want this behavior, comment out the hooks in ".ddev/config.xhgui.yaml".
+      $homeDir = getenv('HOME');
+      $globalAutoload = $homeDir . '/.composer/vendor/autoload.php';
+      if (file_exists($globalAutoload)) {
+        require_once $globalAutoload;
+      }
       return;
       EOF
   pre-stop:

--- a/config.xhgui.yaml
+++ b/config.xhgui.yaml
@@ -23,11 +23,6 @@ hooks:
       } else {
         error_log("Global autoloader not found at: $globalAutoload");
       }
-      use Xhgui\Profiler\Profiler;
-      if (!extension_loaded('xhprof')) {
-        error_log("xhprof extension not loaded.");
-        return;
-      }
       EOF
   - exec: |
       cat <<-'EOF' >> /var/www/html/${DDEV_DOCROOT}/sites/default/settings.ddev.php
@@ -35,7 +30,7 @@ hooks:
         require_once "/mnt/ddev_config/xhgui/collector/xhgui.collector.php";
       }
       EOF
-    
+
 pre-stop:
   - exec: |
       cat <<-EOF > .ddev/xhprof/xhprof_prepend.php

--- a/config.xhgui.yaml
+++ b/config.xhgui.yaml
@@ -10,26 +10,7 @@ hooks:
       fi
     service: db
   - exec: |
-      cat <<-'EOF' > .ddev/xhprof/xhprof_prepend.php
-      <?php
-      // DDEV's built in xhprof handler breaks our own.
-      // We'll temporarily override it here, but return control back later.
-      // If you don't want this behavior, comment out the hooks in ".ddev/config.xhgui.yaml".
-      $homeDir = getenv('HOME');
-      $globalAutoload = $homeDir . '/.composer/vendor/autoload.php';
-      if (file_exists($globalAutoload)) {
-        require_once $globalAutoload;
-        // echo "Global autoloader loaded successfully from: $globalAutoload\n";        
-      } else {
-        error_log("Global autoloader not found at: $globalAutoload");
-      }
-      EOF
-  - exec: |
-      cat <<-'EOF' >> /var/www/html/${DDEV_DOCROOT}/sites/default/settings.ddev.php
-      if (file_exists("/mnt/ddev_config/xhgui/collector/xhgui.collector.php")) {
-        require_once "/mnt/ddev_config/xhgui/collector/xhgui.collector.php";
-      }
-      EOF
+      cp .ddev/xhgui_prepend.php .ddev/xhprof/xhprof_prepend.php
 
 pre-stop:
   - exec: |

--- a/config.xhgui.yaml
+++ b/config.xhgui.yaml
@@ -10,11 +10,11 @@ hooks:
       fi
     service: db
   - exec: |
-      cp .ddev/xhgui_prepend.php .ddev/xhprof/xhprof_prepend.php
+      cp /var/www/html/.ddev/xhgui_prepend.php /var/www/html/.ddev/xhprof/xhprof_prepend.php
 
-pre-stop:
+  pre-stop:
   - exec: |
-      cat <<-EOF > .ddev/xhprof/xhprof_prepend.php
+      cat <<-EOF > /var/www/html/.ddev/xhprof/xhprof_prepend.php
       <?php
       // #ddev-generated
       // We'll give back control of this file to DDEV. Next time it checks, it will see it has ownership

--- a/config.xhgui.yaml
+++ b/config.xhgui.yaml
@@ -19,10 +19,24 @@ hooks:
       $globalAutoload = $homeDir . '/.composer/vendor/autoload.php';
       if (file_exists($globalAutoload)) {
         require_once $globalAutoload;
+        // echo "Global autoloader loaded successfully from: $globalAutoload\n";        
+      } else {
+        error_log("Global autoloader not found at: $globalAutoload");
       }
-      return;
+      use Xhgui\Profiler\Profiler;
+      if (!extension_loaded('xhprof')) {
+        error_log("xhprof extension not loaded.");
+        return;
+      }
       EOF
-  pre-stop:
+  - exec: |
+      cat <<-'EOF' >> /var/www/html/${DDEV_DOCROOT}/sites/default/settings.ddev.php
+      if (file_exists("/mnt/ddev_config/xhgui/collector/xhgui.collector.php")) {
+        require_once "/mnt/ddev_config/xhgui/collector/xhgui.collector.php";
+      }
+      EOF
+    
+pre-stop:
   - exec: |
       cat <<-EOF > .ddev/xhprof/xhprof_prepend.php
       <?php

--- a/install.yaml
+++ b/install.yaml
@@ -7,6 +7,7 @@ project_files:
 - docker-compose.xhgui_norouter.yaml
 - config.xhgui.yaml
 - commands/host/xhgui
+- web-build/Dockerfile.xhgui
 - xhgui/Dockerfile
 - xhgui/xhgui.config.php
 - xhgui/collector/xhgui.collector.config.php

--- a/install.yaml
+++ b/install.yaml
@@ -8,6 +8,7 @@ project_files:
 - config.xhgui.yaml
 - commands/host/xhgui
 - web-build/Dockerfile.xhgui
+- xhgui_prepend.php
 - xhgui/Dockerfile
 - xhgui/xhgui.config.php
 - xhgui/collector/xhgui.collector.config.php

--- a/web-build/Dockerfile.xhgui
+++ b/web-build/Dockerfile.xhgui
@@ -1,0 +1,5 @@
+#ddev-generated
+# Globally composer-install php-profiler with current php and composer
+USER ${username}
+RUN composer global require perftools/php-profiler
+USER root

--- a/web-build/Dockerfile.xhgui
+++ b/web-build/Dockerfile.xhgui
@@ -1,5 +1,5 @@
 #ddev-generated
 # Globally composer-install php-profiler with current php and composer
 USER ${username}
-RUN composer global require perftools/php-profiler
+RUN composer global require perftools/php-profiler --dev
 USER root

--- a/xhgui_prepend.php
+++ b/xhgui_prepend.php
@@ -1,0 +1,15 @@
+<?php
+// #ddev-generated
+// xhgui_prepend.php is copied to xhprof_prepend.php to set up xhgui
+// Overrides DDEV's built in xhprof handler.
+$homeDir = getenv('HOME');
+$globalAutoload = $homeDir . '/.composer/vendor/autoload.php';
+if (file_exists($globalAutoload)) {
+    require_once $globalAutoload;
+    // echo "Global autoloader loaded successfully from: $globalAutoload\n";
+} else {
+    error_log("Global autoloader not found at: $globalAutoload");
+}
+if (file_exists("/mnt/ddev_config/xhgui/collector/xhgui.collector.php")) {
+    require_once "/mnt/ddev_config/xhgui/collector/xhgui.collector.php";
+}


### PR DESCRIPTION
## The Issue

* #33 
* #30 

## How This PR Solves The Issue

* Install [perftools/php-profiler](https://github.com/perftools/php-profiler) globally using custom Dockerfile
* Load the profiler using the xhprof_prepend.php override
* Update the README to remove the configuration requirements

## Manual Testing Instructions

Install with 
```
ddev add-on get https://github.com/rfay/ddev-xhgui/tarball/20250102_autoconfig_php_profiler
```

Try it out in several environments.

The new rendered readme is at https://github.com/ddev/ddev-xhgui/blob/196d4a9de5ea4e42d0b8ea8d337cd48cb572e9d2/README.md

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

