### PR TITLE
fix: use correct autoloader and bump to 0.23.2

### DIFF
--- a/docker-compose.xhgui.yaml
+++ b/docker-compose.xhgui.yaml
@@ -4,7 +4,7 @@ services:
     # https://hub.docker.com/r/xhgui/xhgui/tags
     build:
       dockerfile_inline: |
-        FROM xhgui/xhgui:0.23.0
+        FROM xhgui/xhgui:0.23.2
         RUN echo 'memory_limit=512M' >> $$PHP_INI_DIR/conf.d/99-memory-limit.ini
     container_name: ddev-${DDEV_SITENAME}-xhgui
     labels:

--- a/xhgui_prepend.php
+++ b/xhgui_prepend.php
@@ -3,7 +3,7 @@
 // xhgui_prepend.php is copied to xhprof_prepend.php to set up xhgui
 // Overrides DDEV's built in xhprof handler.
 $homeDir = getenv('HOME');
-$globalAutoload = $homeDir . '/.composer/vendor/autoload.php';
+$globalAutoload = $homeDir . '/.composer/vendor/perftools/php-profiler/autoload.php';
 if (file_exists($globalAutoload)) {
     require_once $globalAutoload;
     // echo "Global autoloader loaded successfully from: $globalAutoload\n";


### PR DESCRIPTION
## The Issue

TYPO3 cannot work with XHGui because we use an incorrect autoloader file:

- https://github.com/ddev/ddev/issues/7170

## How This PR Solves The Issue

Using https://github.com/ddev/ddev/pull/7172:

- Bumps xhgui to 0.23.2
- Uses correct autoloader for php-profiler, see https://github.com/perftools/php-profiler#autoloader

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-xhgui/tarball/20250331_stasadev_autoloader_and_bump
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
